### PR TITLE
Getting it happening, part deux

### DIFF
--- a/execution-engine/contract-ffi/src/gens.rs
+++ b/execution-engine/contract-ffi/src/gens.rs
@@ -129,7 +129,8 @@ pub fn cl_value_arb() -> impl Strategy<Value = CLValue> {
             | CLType::Tuple7(_)
             | CLType::Tuple8(_)
             | CLType::Tuple9(_)
-            | CLType::Tuple10(_) => (),
+            | CLType::Tuple10(_)
+            | CLType::Any => (),
         }
     };
 

--- a/execution-engine/contract-ffi/src/value/cl_type.rs
+++ b/execution-engine/contract-ffi/src/value/cl_type.rs
@@ -61,6 +61,7 @@ pub enum CLType {
     Tuple8([Box<CLType>; 8]),
     Tuple9([Box<CLType>; 9]),
     Tuple10([Box<CLType>; 10]),
+    Any,
 }
 
 impl CLType {
@@ -80,7 +81,8 @@ impl CLType {
                 | CLType::Unit
                 | CLType::String
                 | CLType::Key
-                | CLType::URef => 0,
+                | CLType::URef
+                | CLType::Any => 0,
                 CLType::Option(cl_type) | CLType::List(cl_type) => cl_type.serialized_len(),
                 CLType::FixedList(cl_type, list_len) => {
                     cl_type.serialized_len() + list_len.to_le_bytes().len()
@@ -135,6 +137,7 @@ enum CLTypeTag {
     Tuple8 = 25,
     Tuple9 = 26,
     Tuple10 = 27,
+    Any = 28,
 }
 
 impl CLType {
@@ -206,6 +209,7 @@ impl CLType {
             CLType::Tuple10(cl_type_array) => {
                 serialize_cl_tuple_type(CLTypeTag::Tuple10 as u8, cl_type_array, stream)
             }
+            CLType::Any => stream.push(CLTypeTag::Any as u8),
         }
     }
 }

--- a/execution-engine/engine-core/src/execution/executor.rs
+++ b/execution-engine/engine-core/src/execution/executor.rs
@@ -11,7 +11,7 @@ use contract_ffi::{
     bytesrepr::{self, FromBytes},
     execution::Phase,
     key::Key,
-    value::{account::PublicKey, CLTyped, CLValue, ProtocolVersion},
+    value::{account::PublicKey, CLType, CLTyped, CLValue, ProtocolVersion},
 };
 use engine_shared::{
     account::Account, gas::Gas, newtypes::CorrelationId, stored_value::StoredValue,
@@ -110,7 +110,7 @@ impl Executor {
         // only nonce update can be returned.
         let effects_snapshot = tc.borrow().effect();
 
-        let arguments: Vec<CLValue> = if args.is_empty() {
+        let arguments: Vec<Vec<u8>> = if args.is_empty() {
             Vec::new()
         } else {
             // TODO: figure out how this works with the cost model
@@ -118,6 +118,14 @@ impl Executor {
             let gas = Gas::new(args.len().into());
             on_fail_charge!(bytesrepr::deserialize(args), gas, effects_snapshot)
         };
+
+        let arguments = arguments
+            .into_iter()
+            .map(|bytes: Vec<u8>| {
+                println!("bytes: {:?}", bytes);
+                CLValue::from_components(CLType::Any, bytes)
+            })
+            .collect();
 
         let context = RuntimeContext::new(
             tc,

--- a/execution-engine/engine-core/src/execution/executor.rs
+++ b/execution-engine/engine-core/src/execution/executor.rs
@@ -121,10 +121,7 @@ impl Executor {
 
         let arguments = arguments
             .into_iter()
-            .map(|bytes: Vec<u8>| {
-                println!("bytes: {:?}", bytes);
-                CLValue::from_components(CLType::Any, bytes)
-            })
+            .map(|bytes: Vec<u8>| CLValue::from_components(CLType::Any, bytes))
             .collect();
 
         let context = RuntimeContext::new(

--- a/execution-engine/engine-core/src/runtime_context/mod.rs
+++ b/execution-engine/engine-core/src/runtime_context/mod.rs
@@ -497,7 +497,8 @@ where
                 | CLType::Tuple7(_)
                 | CLType::Tuple8(_)
                 | CLType::Tuple9(_)
-                | CLType::Tuple10(_) => Ok(()),
+                | CLType::Tuple10(_)
+                | CLType::Any => Ok(()),
                 CLType::Key => {
                     let key: Key = cl_value.to_owned().into_t()?; // TODO: optimize?
                     self.validate_key(&key)

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/state/cl_type.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/state/cl_type.rs
@@ -131,6 +131,9 @@ impl From<CLType> for state::CLType {
                 pb_tuple10.set_type8((*types[8].clone()).into());
                 pb_tuple10.set_type9((*types[9].clone()).into());
             }
+            CLType::Any => {
+                let _pb_any = pb_type.mut_any_type();
+            }
         };
         pb_type
     }
@@ -327,6 +330,7 @@ impl TryFrom<state::CLType> for CLType {
                     Box::new(type9),
                 ])
             }
+            CLType_oneof_variants::any_type(_) => CLType::Any,
         };
         Ok(cl_type)
     }

--- a/protobuf/io/casperlabs/casper/consensus/state.proto
+++ b/protobuf/io/casperlabs/casper/consensus/state.proto
@@ -127,6 +127,8 @@ message CLType {
         CLType type9 = 10;
     }
 
+    message Any {}
+
     oneof variants {
         Simple simple_type = 1;
         Option option_type = 2;
@@ -144,6 +146,7 @@ message CLType {
         Tuple8 tuple8_type = 14;
         Tuple9 tuple9_type = 15;
         Tuple10 tuple10_type = 16;
+        Any any_type = 17;
     }
 }
 


### PR DESCRIPTION
This got the first set of tests passing. I'm running the rest now locally...

You'll notice that I had to undo the fancy new `ToBytes` and `FromBytes` impls for `Vec<u8>`.  They were garbling in the serialized bytes of the `U512` supplied to standard payment.  I suspect that they are correct when used together, but have deviated from the original definiton (which is why the roundtrip tests would pass).

I do really like the new de/serializers, so it would be worth seeing if we could fix them.

cc @EdHastingsCasperLabs 