### PR TITLE
EE-938: allow {mint,pos} installer bytes at 'turbo' genesis

### DIFF
--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -214,11 +214,10 @@ where
 
         // Spec #5: Execute the wasm code from the mint installer bytes
         let mint_reference: URef = {
-            let mint_installer_bytes = genesis_config.mint_installer_bytes();
-
-            if !self.config.use_system_contracts() && mint_installer_bytes.is_empty() {
+            if !self.config.use_system_contracts() {
                 store_do_nothing_contract()?
             } else {
+                let mint_installer_bytes = genesis_config.mint_installer_bytes();
                 let mint_installer_module = preprocessor.preprocess(mint_installer_bytes)?;
                 let args = Vec::new();
                 let mut named_keys = BTreeMap::new();
@@ -252,8 +251,6 @@ where
         // Spec #7: Execute pos installer wasm code, passing the initially bonded validators as an
         // argument
         let proof_of_stake_reference: URef = {
-            let proof_of_stake_installer_bytes = genesis_config.proof_of_stake_installer_bytes();
-
             // Spec #6: Compute initially bonded validators as the contents of accounts_path
             // filtered to non-zero staked amounts.
             let bonded_validators: BTreeMap<PublicKey, U512> = genesis_config
@@ -270,7 +267,7 @@ where
             // step
             let partial_protocol_data = ProtocolData::partial_with_mint(mint_reference);
 
-            if !self.config.use_system_contracts() && proof_of_stake_installer_bytes.is_empty() {
+            if !self.config.use_system_contracts() {
                 let uref = {
                     let addr = address_generator.borrow_mut().create_address();
                     URef::new(addr, AccessRights::READ_ADD_WRITE)
@@ -357,6 +354,8 @@ where
                 tracking_copy.borrow_mut().write(key, value);
                 uref
             } else {
+                let proof_of_stake_installer_bytes =
+                    genesis_config.proof_of_stake_installer_bytes();
                 let proof_of_stake_installer_module =
                     preprocessor.preprocess(proof_of_stake_installer_bytes)?;
                 let args = {

--- a/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
@@ -9,6 +9,7 @@ use engine_test_support::internal::{
 };
 use types::{account::PublicKey, Key, ProtocolVersion, U512};
 
+#[cfg(feature = "use-system-contracts")]
 const BAD_INSTALL: &str = "standard_payment.wasm";
 
 const CHAIN_NAME: &str = "Jeremiah";
@@ -105,6 +106,7 @@ fn should_run_genesis() {
     }
 }
 
+#[cfg(feature = "use-system-contracts")]
 #[ignore]
 #[should_panic]
 #[test]
@@ -156,6 +158,7 @@ fn should_fail_if_bad_mint_install_contract_is_provided() {
     builder.run_genesis(&genesis_config);
 }
 
+#[cfg(feature = "use-system-contracts")]
 #[ignore]
 #[should_panic]
 #[test]


### PR DESCRIPTION
Think we should probably do this, so that default genesis (as of today) will still install small do nothing modules instead of big pos/mint modules.